### PR TITLE
Create C++_solution.cpp

### DIFF
--- a/CP/LeetCode/Longest Palindromic Substring/aryanayush012.cpp
+++ b/CP/LeetCode/Longest Palindromic Substring/aryanayush012.cpp
@@ -1,0 +1,27 @@
+class Solution {
+public:
+    string longestPalindrome(string s) {      
+        vector<vector<int>> dp(s.size(),vector<int>(s.size(),0));
+        // len = j-i+1
+        int start = 0;
+        int len = 1;
+        for(int g = 0;g<s.size();g++){
+            for(int i = 0 ,j = g ; j<s.size(); i++, j++){
+                if(g == 0){
+                    dp[i][j] = 1;
+                }
+                else if(g == 1 and s[i] == s[j]){
+                    dp[i][j] = 1;
+                    start = i;
+                    len = 2;
+                }
+                else if(s[i] == s[j] and dp[i+1][j-1] == 1){
+                    dp[i][j] = 1;
+                    start = i;
+                    len = j-i+1;
+                }
+            }
+        }
+        return s.substr(start,len);
+    }
+};


### PR DESCRIPTION
Reverse SSS and become S′S'S 
′
 . Find the longest common substring between SSS and S′S'S 
′
 , which must also be the longest palindromic substring.

This seemed to work, let’s see some examples below.

For example, SSS = "caba", S′S'S 
′
  = "abac".

The longest common substring between SSS and S′S'S 
′
  is "aba", which is the answer.

Let’s try another example: SSS = "abacdfgdcaba", S′S'S 
′
  = "abacdgfdcaba".

The longest common substring between SSS and S′S'S 
′
  is "abacd". Clearly, this is not a valid palindrome.


![image](https://user-images.githubusercontent.com/76223671/193617583-62f4e56c-2fe8-4631-b5d6-87e873e2d779.png)
